### PR TITLE
BUG: Trigger unit testing when draft PR marked ready for review

### DIFF
--- a/.github/workflows/unittest-workflow.yml
+++ b/.github/workflows/unittest-workflow.yml
@@ -2,7 +2,7 @@ name: AFIDs Validator PR Unit Testing
 
 on:
     pull_request:
-        types: [opened, reopened, synchronize]
+        types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
     test:


### PR DESCRIPTION
## Proposed changes

Unit testing was not getting triggered in Github Actions when draft PRs were marked ready for review.
Added `ready_for_review` as a trigger in the Github Actions workflow. 

## Types of changes

What types of changes does your code introduce? Put an `x` in the boxes that apply

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionalitiy)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (if none of the other choices apply)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [ ] Changes pass the unit tests
- [ ] Code has been run through [`black`](https://github.com/psf/black) with the `-l 79` flag.
- [ ] I have included necessary documentation or comments (as necessary)
- [ ] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.

_PR template was adopted from [appium](https://github.com/appium/appium/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_
