### PR TITLE
Use hash of setup.py as cache key

### DIFF
--- a/.github/workflows/afids-validator_ci.yml
+++ b/.github/workflows/afids-validator_ci.yml
@@ -31,7 +31,7 @@ jobs:
         id: cache
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-pip-${{ hashFiles('**/requirements.txt') }}
+          key: ${{ env.pythonLocation }}-pip-${{ hashFiles('**/setup.py') }}
           restore-keys: |
             ${{ env.pythonLocation }}-pip
 


### PR DESCRIPTION
## Proposed changes

The deploy action uses a cached environment, and the key to that cache is currently based on the hash of `requirements.txt`. Because of the change to `requirements.txt` in #145, that file no longer works as a key for the cache, so this PR sets it up to use `setup.py` instead.

## Types of changes

What types of changes does your code introduce? Put an `x` in the boxes that apply

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionalitiy)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (if none of the other choices apply)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [ ] Changes have been tested to ensure that fix is effective or that a feature works.
- [ ] Changes pass the unit tests
- [ ] Code has been run through [`black`](https://github.com/psf/black) with the `-l 79` flag.
- [ ] I have included necessary documentation or comments (as necessary)
- [ ] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.

_PR template was adopted from [appium](https://github.com/appium/appium/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_
