### PR TITLE
MAINT: Split actions workflow between CI and Release

### DIFF
--- a/.github/workflows/afids-validator_ci.yml
+++ b/.github/workflows/afids-validator_ci.yml
@@ -134,5 +134,5 @@ jobs:
         uses: akhileshns/heroku@v3.0.4
         with:
           heroku_api_key: ${{ secrets.HEROKU_TEST_API }}
-          heroku_app_name: afids-validator
+          heroku_app_name: afids-validator-test
           heroku_email: ${{ secrets.HEROKU_EMAIL }}

--- a/.github/workflows/afids-validator_ci.yml
+++ b/.github/workflows/afids-validator_ci.yml
@@ -112,8 +112,8 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
 
-  draft_release:
-    name: Draft and update release
+  draft_changelog:
+    name: Draft and update change log
     needs: [linting]
     runs-on: ubuntu-latest
 
@@ -122,3 +122,12 @@ jobs:
           uses: release-drafter/release-drafter@v5
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy_test:
+    name: Deploy test heroku app
+    needs: [linting]
+    uses: akhileshns/heroku@v3.0.4
+    with:
+      heroku_api_key: ${{ secrets.HEROKU_TEST_API }}
+      heroku_app_name: afids-validator
+      heroku_email: ${{ secrets.HEROKU_EMAIL }}

--- a/.github/workflows/afids-validator_ci.yml
+++ b/.github/workflows/afids-validator_ci.yml
@@ -118,10 +118,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-        - name: Draft and update change log
-          uses: release-drafter/release-drafter@v5
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Draft and update change log
+        uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy_test:
     name: Deploy test heroku app

--- a/.github/workflows/afids-validator_ci.yml
+++ b/.github/workflows/afids-validator_ci.yml
@@ -126,8 +126,13 @@ jobs:
   deploy_test:
     name: Deploy test heroku app
     needs: [linting]
-    uses: akhileshns/heroku@v3.0.4
-    with:
-      heroku_api_key: ${{ secrets.HEROKU_TEST_API }}
-      heroku_app_name: afids-validator
-      heroku_email: ${{ secrets.HEROKU_EMAIL }}
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - name: Deploy test heroku app
+        uses: akhileshns/heroku@v3.0.4
+        with:
+          heroku_api_key: ${{ secrets.HEROKU_TEST_API }}
+          heroku_app_name: afids-validator
+          heroku_email: ${{ secrets.HEROKU_EMAIL }}

--- a/.github/workflows/afids-validator_ci.yml
+++ b/.github/workflows/afids-validator_ci.yml
@@ -133,6 +133,6 @@ jobs:
       - name: Deploy test heroku app
         uses: akhileshns/heroku@v3.0.4
         with:
-          heroku_api_key: ${{ secrets.HEROKU_TEST_API }}
+          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
           heroku_app_name: afids-validator-test
           heroku_email: ${{ secrets.HEROKU_EMAIL }}

--- a/.github/workflows/afids-validator_ci.yml
+++ b/.github/workflows/afids-validator_ci.yml
@@ -1,4 +1,4 @@
-name: AFIDs Validator CI/CD Workflow
+name: AFIDs Validator CI Workflow
 
 on:
   pull_request:
@@ -112,7 +112,7 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
 
-  bump_version:
+  draft_release:
     name: Draft and update release
     needs: [linting]
     runs-on: ubuntu-latest
@@ -122,48 +122,3 @@ jobs:
           uses: release-drafter/release-drafter@v5
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  deploy:
-    name: Deploy and release
-    needs: [test]
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
-
-    steps:
-      - name: Checkout master
-        uses: actions/checkout@master
-        with:
-          ref: refs/heads/master
-
-      - name: Deploy heroku app
-        uses: akhileshns/heroku-deploy@v3.0.4
-        with:
-          heroku_api_key: ${{ secrets.HEROKU_API_KEY }} # Heroku API Key
-          heroku_app_name: afids-validator # Heroku app name
-          heroku_email: ${{ secrets.HEROKU_EMAIL }} # Heroku email
-
-      - name: Publish change log
-        id: update_version
-        uses: release-drafter/release-drafter@v5
-        with:
-          publish: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Update setup.py version
-        uses: jacobtomlinson/gha-find-replace@master
-        with:
-          include: "setup.py"
-          find: "v[0-9]+.[0-9]+.[0-9]+"
-          replace: "${{ steps.update_version.outputs.tag_name }}"
-
-      - name: Commit setup.py
-        run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git commit -m "Update setup.py version" -a
-
-      - name: Push to master
-        uses: ad-m/github-push-action@master
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/afids-validator_release.yml
+++ b/.github/workflows/afids-validator_release.yml
@@ -35,6 +35,6 @@ jobs:
     - name: Deploy heroku app
       uses: akhileshns/heroku@v3.0.4
       with:
-        heroku_api_key: ${{ secrets.HEROKU_PROD_API }} ## UPDATE TO USE PRODUCTION API
+        heroku_api_key: ${{ secrets.HEROKU_PROD_API }}
         heroku_app_name: afids-validator
         heroku_email: ${{ secrets.HEROKU_EMAIL }}

--- a/.github/workflows/afids-validator_release.yml
+++ b/.github/workflows/afids-validator_release.yml
@@ -35,6 +35,6 @@ jobs:
       - name: Deploy heroku app
         uses: akhileshns/heroku@v3.0.4
         with:
-          heroku_api_key: ${{ secrets.HEROKU_PROD_API }}
+          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
           heroku_app_name: afids-validator
           heroku_email: ${{ secrets.HEROKU_EMAIL }}

--- a/.github/workflows/afids-validator_release.yml
+++ b/.github/workflows/afids-validator_release.yml
@@ -32,6 +32,12 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Modify release to match release versions
+        run: |
+          git tag -a v${{ steps.semver_checkout.outputs.version }}
+          git push
+          git push origin -f v${{ steps.semver_checkout.outputs.version }}
+
       - name: Deploy heroku app
         uses: akhileshns/heroku@v3.0.4
         with:

--- a/.github/workflows/afids-validator_release.yml
+++ b/.github/workflows/afids-validator_release.yml
@@ -1,0 +1,41 @@
+name: AFIDs Validator Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    name: Deploy and release
+    runs-on: ubuntu-latest
+
+  steps:
+    - name: Checkout master
+      uses: actions/checkout@master
+      with:
+        ref: refs/heads/master
+
+    - name: Update setup.py version
+      uses: jacobtomlinson/gha-find-replace@master
+      with:
+        include: "setup.py"
+        find: "v[0-9]+.[0-9]+.[0-9]+"
+        replace: "${{ steps.update_version.outputs.tag_name }}"
+
+    - name: Commit setup.py
+      run: |
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git commit -m "Update setup.py version" -a
+
+    - name: Push to master
+      uses: ad-m/github-push-action@master
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Deploy heroku app
+      uses: akhileshns/heroku@v3.0.4
+      with:
+        heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
+        heroku_app_name: afids-validator
+        heroku_email: ${{ secrets.HEROKU_EMAIL }}

--- a/.github/workflows/afids-validator_release.yml
+++ b/.github/workflows/afids-validator_release.yml
@@ -9,32 +9,32 @@ jobs:
     name: Deploy and release
     runs-on: ubuntu-latest
 
-  steps:
-    - name: Checkout latest tag
-      id: semver_checkout
-      uses: EasyDesk/action-semver-checkout@v1
+    steps:
+      - name: Checkout latest tag
+        id: semver_checkout
+        uses: EasyDesk/action-semver-checkout@v1
 
-    - name: Update setup.py version
-      uses: jacobtomlinson/gha-find-replace@master
-      with:
-        include: "setup.py"
-        find: "v[0-9]+.[0-9]+.[0-9]+"
-        replace: "v${{ steps.semver_checkout.outputs.version }}"
+      - name: Update setup.py version
+        uses: jacobtomlinson/gha-find-replace@master
+        with:
+          include: "setup.py"
+          find: "v[0-9]+.[0-9]+.[0-9]+"
+          replace: "v${{ steps.semver_checkout.outputs.version }}"
 
-    - name: Commit setup.py
-      run: |
-        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git config --local user.name "github-actions[bot]"
-        git commit -m "Update setup.py version" -a
+      - name: Commit setup.py
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -m "Update setup.py version" -a
 
-    - name: Push to master
-      uses: ad-m/github-push-action@master
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push to master
+        uses: ad-m/github-push-action@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Deploy heroku app
-      uses: akhileshns/heroku@v3.0.4
-      with:
-        heroku_api_key: ${{ secrets.HEROKU_PROD_API }}
-        heroku_app_name: afids-validator
-        heroku_email: ${{ secrets.HEROKU_EMAIL }}
+      - name: Deploy heroku app
+        uses: akhileshns/heroku@v3.0.4
+        with:
+          heroku_api_key: ${{ secrets.HEROKU_PROD_API }}
+          heroku_app_name: afids-validator
+          heroku_email: ${{ secrets.HEROKU_EMAIL }}

--- a/.github/workflows/afids-validator_release.yml
+++ b/.github/workflows/afids-validator_release.yml
@@ -10,17 +10,16 @@ jobs:
     runs-on: ubuntu-latest
 
   steps:
-    - name: Checkout master
-      uses: actions/checkout@master
-      with:
-        ref: refs/heads/master
+    - name: Checkout latest tag
+      id: semver_checkout
+      uses: EasyDesk/action-semver-checkout@v1
 
     - name: Update setup.py version
       uses: jacobtomlinson/gha-find-replace@master
       with:
         include: "setup.py"
         find: "v[0-9]+.[0-9]+.[0-9]+"
-        replace: "${{ steps.update_version.outputs.tag_name }}"
+        replace: "v${{ steps.semver_checkout.outputs.version }}"
 
     - name: Commit setup.py
       run: |
@@ -36,6 +35,6 @@ jobs:
     - name: Deploy heroku app
       uses: akhileshns/heroku@v3.0.4
       with:
-        heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
+        heroku_api_key: ${{ secrets.HEROKU_PROD_API }} ## UPDATE TO USE PRODUCTION API
         heroku_app_name: afids-validator
         heroku_email: ${{ secrets.HEROKU_EMAIL }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 *.pyc
 .*env/
+.env
 .vscode/
 afids.code-workspace
 *.egg-info

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 [![AFIDs](https://github.com/afids/afids-validator/blob/master/afidsvalidator/static/images/banner.png)](./static/images/banner.png)
 
 [![](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2Fafids_project)](https://twitter.com/afids_project)
-[![AFIDs Validator CI/CD](https://github.com/afids/afids-validator/actions/workflows/afids-validator_ci.yml/badge.svg)](https://github.com/afids/afids-validator/actions/workflows/afids-validator_ci.yml)
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![AFIDs Validator CI](https://github.com/afids/afids-validator/actions/workflows/afids-validator_ci.yml/badge.svg)](https://github.com/afids/afids-validator/actions/workflows/afids-validator_ci.yml)
+[![AFIDs Validator Release](https://github.com/afids/afids-validator/actions/workflows/afids-validator_release.yml/badge.svg)](https://github.com/afids/afids-validator/actions/workflows/afids-validator_release.yml)
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/afids/afids-validator?sort=semver)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 Anatomical fiducials (AFIDs) is an open framework for evaluating correspondence in brain images and teaching neuroanatomy using anatomical fiducial placement. The AFIDs Validator project aims to build a web application that allows the user to upload an FCSV file generated using the AFIDs protocol, and validate that it conforms to the protocol.


### PR DESCRIPTION
## Proposed changes

This splits the actions workflow into separate testing and release workflows. Additionally reverts releases to manual trigger, which was done to avoid those `skip_changelog` automatic version bumps. 

PR also introduces separate heroku apps for testing and release. Production heroku app (the current `afids-validator`) will only be deployed on release. Otherwise, non-release merges that trigger the testing workflow will be deployed to a test heroku app (`afids-validator-test`).

There are probably some configs we need to set up for the `afids-validator-test` app

## Types of changes

What types of changes does your code introduce? Put an `x` in the boxes that apply

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionalitiy)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (if none of the other choices apply)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [ ] Changes have been tested to ensure that fix is effective or that a feature works.
- [ ] Changes pass the unit tests
- [x] Code has been run through [`black`](https://github.com/psf/black) with the `-l 79` flag.
- [x] I have included necessary documentation or comments (as necessary)
- [ ] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.

_PR template was adopted from [appium](https://github.com/appium/appium/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_
