### PR TITLE
Use push-protected for releases

### DIFF
--- a/.github/workflows/afids-validator_release.yml
+++ b/.github/workflows/afids-validator_release.yml
@@ -51,9 +51,11 @@ jobs:
           git diff-index --quiet HEAD || git commit -m "Bump version to $LATEST_VERSION" -a
 
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: CasperWA/push-protected@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.event.pull_request.base.ref }}
+          token: ${{ secrets.BP_PAT_TOKEN }}
+          unprotect_reviews: true
 
       - name: Publish change log
         uses: release-drafter/release-drafter@v5

--- a/.github/workflows/afids-validator_release.yml
+++ b/.github/workflows/afids-validator_release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Push changes
         uses: CasperWA/push-protected@v2
         with:
-          branch: ${{ github.event.pull_request.base.ref }}
+          branch: master
           token: ${{ secrets.BP_PAT_TOKEN }}
           unprotect_reviews: true
 


### PR DESCRIPTION
## Proposed changes

The release workflow fails to push changes to pyproject.toml because `master` is protected. This uses the same fix earlier applied to the CI workflow.

## Types of changes

What types of changes does your code introduce? Put an `x` in the boxes that apply

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionalitiy)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (if none of the other choices apply)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [ ] Changes have been tested to ensure that fix is effective or that a feature works.
- [ ] Changes pass the unit tests
- [ ] Code has been run through [`black`](https://github.com/psf/black) with the `-l 79` flag.
- [ ] I have included necessary documentation or comments (as necessary)
- [ ] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.

_PR template was adopted from [appium](https://github.com/appium/appium/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_
